### PR TITLE
Initial proposal of the gitlab-ci-workspace docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+sudo: required
+
+services:
+  - docker
+
+before_install:
+  # Dockerfile linting tool.
+  # https://github.com/phase2/hadolint/hadolint
+  - docker pull hadolint/hadolint
+  # Double-check the version of Docker travis will use.
+  - docker --version
+
+script:
+  # Lint the Dockerfile.
+  - docker run --rm -i hadolint/hadolint hadolint - < Dockerfile
+  # Test that the image build.
+  - docker build -t outrigger/gitlab-ci-workspace:tmp .
+  # Version check our tools
+  # If any tool is not present, the versions script will abort and the test run will fail.
+  - docker run --rm outrigger/gitlab-ci-workspace:tmp /versions.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,6 @@ script:
   # Version check our tools
   # If any tool is not present, the versions script will abort and the test run will fail.
   - docker run --rm outrigger/gitlab-ci-workspace:tmp /versions.sh
+  # Take a closer look at the image.
+  - docker image inspect outrigger/gitlab-ci-workspace:tmp
+  

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ before_install:
   - docker --version
 
 script:
-  # Lint the Dockerfile.
-  - docker run --rm -i hadolint/hadolint hadolint - < Dockerfile
+  # Lint the Dockerfile. Suppressing rules for pinning to specific dependency versions.
+  - docker run --rm -i hadolint/hadolint hadolint --ignore SC2046 --ignore DL3018 --ignore DL3013 - < Dockerfile
   # Test that the image build.
   - docker build -t outrigger/gitlab-ci-workspace:tmp .
   # Version check our tools

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ sudo: required
 services:
   - docker
 
+# General purpose travis instance.
+# No language designation defaults to Ruby.
+language: bash
+
 before_install:
   # Dockerfile linting tool.
   # https://github.com/phase2/hadolint/hadolint

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ LABEL maintainer="Phase2 <outrigger@phase2technology.com>" \
   org.label-schema.vendor="Phase2 <outrigger@phase2technology.com>" \
   name="Outrigger GitLab CI Workspace" \
   org.label-schema.name="Outrigger GitLab CI Workspace" \
-  org.label-schema.description="A GitLab CI workbench ready for a container-based pipeline" \
+  org.label-schema.description="A GitLab CI workbench ready to support a container-based pipeline." \
   org.label-schema.vcs-url="https://github.com/phase2/docker-gitlab-ci-workspace" \
   org.label-schema.schema-version="1.0"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM docker:18
+
+# @see http://label-schema.org/rc1/
+LABEL maintainer="Phase2 <outrigger@phase2technology.com>" \
+  # Replacement for the old MAINTAINER directive has fragmented.
+  org.label-schema.vendor="Phase2 <outrigger@phase2technology.com>" \
+  name="Outrigger GitLab CI Workspace" \
+  org.label-schema.name="Outrigger GitLab CI Workspace" \
+  org.label-schema.description="A GitLab CI workbench ready for a container-based pipeline" \
+  org.label-schema.vcs-url="https://github.com/phase2/docker-gitlab-ci-workspace" \
+  org.label-schema.schema-version="1.0"
+
+RUN apk add --no-cache \
+    bash \
+    curl \
+    openssl \
+    py2-pip \
+        && \
+    # Install Python tools
+    pip install docker-compose \
+        && \
+    # Install Kubernetes & Environment Management tools
+    curl -o /usr/local/bin/kubectl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \
+    chmod +x /usr/local/bin/kubectl && \
+    # Consider skipping the curlbash: https://github.com/lachie83/k8s-helm/blob/v2.8.2/Dockerfile
+    curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get | bash && \
+    helm init --client-only
+
+COPY root /

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,9 @@
-FROM docker:18
+# docker build --build-arg DOCKER_ENGINE_VERSION=18.04 --tag outrigger/gitlab-ci-workspace .
+# Default to the most recent v18 release at the time of the build.
+# To grab the most recent version, specify 'latest'
+ARG DOCKER_ENGINE_VERSION=18
+
+FROM docker:$DOCKER_ENGINE_VERSION
 
 # @see http://label-schema.org/rc1/
 LABEL maintainer="Phase2 <outrigger@phase2technology.com>" \

--- a/README.md
+++ b/README.md
@@ -1,0 +1,52 @@
+# Outrigger GitLab CI Workspace
+
+> A GitLab CI workbench ready to support a container-based pipeline.
+
+[![GitHub tag](https://img.shields.io/github/tag/phase2/docker-gitlab-ci-workspace.svg)](https://github.com/phase2/docker-gitlab-ci-workspace) [![Docker Stars](https://img.shields.io/docker/stars/outrigger/gitlab-ci-workspace.svg)](https://hub.docker.com/r/outrigger/gitlab-ci-workspace) [![Docker Pulls](https://img.shields.io/docker/pulls/outrigger/gitlab-ci-workspace.svg)](https://hub.docker.com/r/outrigger/gitlab-ci-workspace) [![](https://images.microbadger.com/badges/image/outrigger/gitlab-ci-workspace:latest.svg)](https://microbadger.com/images/outrigger/gitlab-ci-workspace:latest "Get your own image badge on microbadger.com")
+
+GitLab CI allows specification of a Docker image which will be pulled and started
+as the first step of each job in every pipeline. For pipelines which will build
+and deploy Docker images, a container based on the official Docker image is best.
+
+We have extended that with additional tools:
+
+* BASH, curl, OpenSSL to facilitate common build operations and expectations.
+* Python for docker-compose and potentially future addition of aws-cli and gcloud.
+* Kubernetes environment ready: built with kubectl and helm for k8s-ing.
+
+Why are all these things built into this one image? We might pull some of these tools out in the future,
+but the goal of this image is not to be a lean, single-purpose Docker image, but to provide an immutable
+and quick-to-load CI environment.
+
+## Usage Example
+
+### Running Locally
+
+This is how you might start up the Container locally to explore environment assumptions:
+
+```
+docker run --rm -it -v /var/run/docker.sock:/var/run/docker.sock outrigger/gitlab-ci-workspace bash
+```
+
+The volume mount allows the container to start and manage Docker containers for the host system.
+
+### Using in .gitlab-ci.yml
+
+```
+# Configuration for the GitLab CI pipeline.
+# https://docs.gitlab.com/ce/ci/yaml/
+image: outrigger/gitlab-ci-workbench:18
+
+services:
+  - docker:18-dind
+
+# <...>
+```
+
+## Security Reports
+
+Please email outrigger@phase2technology.com with security concerns.
+
+## Maintainers
+
+[![Phase2 Logo](https://s3.amazonaws.com/phase2.public/logos/phase2-logo.png)](https://www.phase2technology.com)

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+docker build -t outrigger/gitlab-ci-workspace .

--- a/root/versions.sh
+++ b/root/versions.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -e
+
+echo "---------------"
+echo "Installed Tools"
+echo "---------------"
+docker --version
+docker-compose --version
+python --version
+pip --version
+echo "kubectl:" $(kubectl version --client --short)
+echo "helm:" $(helm version --client --short)

--- a/root/versions.sh
+++ b/root/versions.sh
@@ -9,3 +9,5 @@ python --version
 pip --version
 echo "kubectl:" $(kubectl version --client --short)
 echo "helm:" $(helm version --client --short)
+echo "---------------"
+echo


### PR DESCRIPTION
This is derived from what I see us using in initial experiments with GitLab CI. I expect it will save some installation time, which is the goal.

While we discussed naming this something like gitlab-ci-runner, that name is commonly used for creating a containerized runner - a host for the kind of container we mean to create, which is more akin to a Jenkins workspace.

You will note that I've seeded this with an initial take on some basic Travis testing for the image.